### PR TITLE
Changed invalid 'localhost' URL in grafting.mdx

### DIFF
--- a/website/pages/en/cookbook/grafting.mdx
+++ b/website/pages/en/cookbook/grafting.mdx
@@ -42,7 +42,7 @@ By adhering to these guidelines, you minimize risks and ensure a smoother migrat
 
 ## Building an Existing Subgraph
 
-Building subgraphs is an essential part of The Graph, described more in depth [here](http://localhost:3000/en/cookbook/quick-start/). To be able to build and deploy the existing subgraph used in this tutorial, the following repo is provided:
+Building subgraphs is an essential part of The Graph, described more in depth [here](https://thegraph.com/docs/en/cookbook/quick-start/). To be able to build and deploy the existing subgraph used in this tutorial, the following repo is provided:
 
 - [Subgraph example repo](https://github.com/t-proctor/grafting-tutorial)
 


### PR DESCRIPTION
In the "Building an Existing Subgraph" section, the 'described more in depth here` uses an invalid 'localhost' URL